### PR TITLE
Add mandatory "perl" META field

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,4 +1,5 @@
 {
+    "perl"        : "6.*",
     "name"        : "colomon::App::TagTools",
     "version"     : "*",
     "description" : "Scripts for manipulating MP3 tags",

--- a/bin/tags-to-filename
+++ b/bin/tags-to-filename
@@ -32,6 +32,7 @@ sub MAIN(*@files) {
         $title .= subst(/ <:!ASCII> /, "_", :global);
         $title .= subst(":", "-", :global);
         $title .= subst(";", "-", :global);
+        $title .= subst(",", "-", :global);
 
         my $new-filename = sprintf($track-number-template, $tags.track) ~ $title ~ ".mp3";
 


### PR DESCRIPTION
The `perl` field specifies the minimal perl version for which this distribution can be installed and is a mandatory field. The value of `"6.*"` indicates any version suffices.

It is recommended to use [Test::META](https://modules.perl6.org/repo/Test::META) module as an author test, to catch any issues with the META file.
